### PR TITLE
Confirm, when executing bid, that the currency is still wETH

### DIFF
--- a/contracts/PartyBidRA.sol
+++ b/contracts/PartyBidRA.sol
@@ -244,6 +244,8 @@ contract PartyBid {
     
     // Ensure that bid amount has not changed 
     require(BidProposals[_proposalId].amount == bid.amount, "PartyBid: Bid amount has changed during proposal voting.");
+    // Ensure that bid currency is still in wETH
+    require(bid.currency == wETHAddress, "PartyBid: Bidder has bid in a non-wETH token.");
 
     // Collect bidshares to calculate NFTResoldValue
     IMarket.BidShares memory bidShares = IMarket(IMediaModified(NFTAddress).marketContract()).bidSharesForToken(auctionID);


### PR DESCRIPTION
The contract currently checks the amount, but a clever bidder could switch out the currency (ie. replacing 3 wETH with 3 USDC). When accepting the bid, the currency should be confirmed for a second time.